### PR TITLE
Support for openstackrc

### DIFF
--- a/actions/src/lib/base.py
+++ b/actions/src/lib/base.py
@@ -15,6 +15,7 @@ class OpenStackBaseAction(Action):
 
     def __init__(self, config):
         super(OpenStackBaseAction, self).__init__(config=config)
+        self.openstackrc = self._get_config_section(config, 'openstackrc')
         self.token = self._get_config_section(config, 'token')
         self.password = self._get_config_section(config, 'password')
         self.parser = None
@@ -23,12 +24,17 @@ class OpenStackBaseAction(Action):
         self.parser = self._get_parser(kwargs.pop('ep'))
         cmd = [self.os_cli_cmd]
         cmd.extend(self.get_cmd(**kwargs))
-        # Copy over curretn environment so that the pythonpath for openstack command is
+        # Copy over current environment so that the pythonpath for openstack command is
         # still available.
         env = os.environ.copy()
-        env.update(self.token or self.password)
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                             env=env)
+        # If available source the openstackrc file before running the command.
+        # The precedence order is openstackrc > token > password
+        if self.openstackrc:
+            cmd[:0] = ['.', self.openstackrc, '&&']
+        else:
+            env.update(self.token or self.password)
+        p = subprocess.Popen(' '.join(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                             env=env, shell=True)
         out, err = p.communicate()
         return self._format_output(out=out, err=err, exit=p.returncode)
 
@@ -38,6 +44,8 @@ class OpenStackBaseAction(Action):
 
     def _get_config_section(self, config, section):
         cfg = config.get(section, {})
+        if not isinstance(cfg, dict):
+            return cfg
         return {k: v for k, v in six.iteritems(cfg) if v}
 
     def _get_parser(self, ep):

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,9 @@
 ---
-# Specify one of sectio token or password. If both are provided token will
-# take precedence. Since tokens are epehemral It might be suitable to use
-# password style authetication.
+# Specify one of section openstackrc,token or password.
+# Precedence order is :
+# openstackrc > token > password
+# Since tokens are epehemral It might often be suitable to use password style authetication.
+openstackrc: ""
 token:
     OS_TOKEN: ""
     OS_URL: ""


### PR DESCRIPTION
- openstackrc is source before running the command
- openstackrc.sh location can be defined in config.yaml. This file
  must be accessible to the user running the command.
