### PR TITLE
Handle special values properly

### DIFF
--- a/actions/src/lib/base.py
+++ b/actions/src/lib/base.py
@@ -33,7 +33,9 @@ class OpenStackBaseAction(Action):
             cmd[:0] = ['.', self.openstackrc, '&&']
         else:
             env.update(self.token or self.password)
-        p = subprocess.Popen(' '.join(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        cmd_str = ' '.join(cmd)
+        self.logger.debug('Generated command "%s"', cmd_str)
+        p = subprocess.Popen(cmd_str, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                              env=env, shell=True)
         out, err = p.communicate()
         return self._format_output(out=out, err=err, exit=p.returncode)

--- a/actions/src/lib/utils.py
+++ b/actions/src/lib/utils.py
@@ -25,8 +25,8 @@ class ArgparseUtils(object):
     def get_type(action):
         if action.type in ArgparseUtils.TYPE_LOOKUP:
             return ArgparseUtils.TYPE_LOOKUP[action.type]
-        # In all these cases the value that will be stored is know so
-        # so we only pick where to append or not.
+        # In all these cases the value that will be stored is known so
+        # so we only pick whether to append or not.
         if isinstance(action, argparse._StoreTrueAction) or \
            isinstance(action, argparse._StoreFalseAction) or \
            isinstance(action, argparse._AppendConstAction):
@@ -67,11 +67,11 @@ class ArgparseUtils(object):
                 return ArgparseUtils.TYPE_LOOKUP[type_](action.default)
             else:
                 action.default
-        if isinstance(action, argparse._StoreTrueAction):
-            return False
-        # For _AppendConstAction so not append by default.
-        if isinstance(action, argparse._StoreFalseAction) or \
+        # For _AppendConstAction do not append by default.
+        if isinstance(action, argparse._StoreTrueAction) or \
            isinstance(action, argparse._AppendConstAction):
+            return False
+        if isinstance(action, argparse._StoreFalseAction):
             return True
 
     @staticmethod
@@ -79,3 +79,16 @@ class ArgparseUtils(object):
         # param name is from the options string of fully expanded
         usable_options = [x for x in action.option_strings if x.startswith('--')]
         return usable_options[0][len('--'):] if usable_options else action.dest
+
+    @staticmethod
+    def is_boolean_included(action, value):
+        """
+        Looking at whether the action is StoreTrueAction, StoreFalseAction or AppendConstAction
+        and at the actual value to decide if the boolean action should be included.
+        """
+        if isinstance(action, argparse._StoreTrueAction) or \
+           isinstance(action, argparse._AppendConstAction):
+            return value
+        if isinstance(action, argparse._StoreFalseAction):
+            return not value
+        return value

--- a/actions/src/wrapper.py
+++ b/actions/src/wrapper.py
@@ -31,5 +31,11 @@ class WrapperAction(OpenStackBaseAction):
                 cli_text.append(action.option_strings[0])
                 cli_text.append(v)
             return cli_text
+        # Special handling for boolean
+        if ArgparseUtils.get_type(action) == 'boolean':
+            include_action = ArgparseUtils.is_boolean_included(action, value)
+            # For booleans we only include the option_string.
+            # e.g. --wait instead of --wait=True.
+            return [action.option_strings[0]] if include_action else None
         # will end up being of the form option_string value
-        return [action.option_strings[0], value]
+        return [action.option_strings[0], str(value)]

--- a/actions/src/wrapper.py
+++ b/actions/src/wrapper.py
@@ -1,3 +1,5 @@
+import six
+
 from lib.base import OpenStackBaseAction
 from lib.utils import ArgparseUtils
 
@@ -37,5 +39,5 @@ class WrapperAction(OpenStackBaseAction):
             # For booleans we only include the option_string.
             # e.g. --wait instead of --wait=True.
             return [action.option_strings[0]] if include_action else None
-        # will end up being of the form option_string value
-        return [action.option_strings[0], str(value)]
+        # will end up being of the form "option_string value"
+        return [action.option_strings[0], six.moves.shlex_quote(str(value))]


### PR DESCRIPTION
- StoreTrue, StoreFalse and StoreConst are now handled like the CLI
  would expect i.e. included only if desired.
- All properties are cast into strings so that the eventual join
  works as expected.

Fixes : https://github.com/StackStorm/openstack/issues/21
