### PR TITLE
Include new parameters for security group

### DIFF
--- a/actions/security.group.rule.create.yaml
+++ b/actions/security.group.rule.create.yaml
@@ -19,19 +19,26 @@ parameters:
         type: string
     format:
         default: json
-        description: 'the output format, defaults to table (choices: html, json, shell,
+        description: 'the output format, defaults to table (choices: json, shell,
             table, value, yaml)'
         type: string
     group:
-        description: Create rule in this security group
+        description: Create rule in this security group (name or ID)
         required: true
         type: string
+    noindent:
+        default: false
+        description: whether to disable indenting the JSON
+        type: boolean
     proto:
         default: tcp
         description: 'IP protocol (icmp, tcp, udp; default: tcp)'
         type: string
+    src-group:
+        description: Source security group (ID only)
+        type: string
     src-ip:
         default: 0.0.0.0/0
-        description: 'Source IP (may use CIDR notation; default: 0.0.0.0/0)'
+        description: 'Source IP address block (may use CIDR notation; default: 0.0.0.0/0)'
         type: string
 runner_type: run-python


### PR DESCRIPTION
- rerun  autogen to create updated meta

Validated -

```
 st2 run openstack.security.group.rule.create group=x src-group=blah
.
id: 56c785c532ed3564fffce077
status: failed
parameters:
  group: x
  src-group: blah
result:
  exit_code: 1
  result: null
  stderr: "st2.actions.python.WrapperAction: DEBUG    Generated command "openstack security group rule create -f json x --src-group blah"
```

Looks like this metadata works as expected.

Note to self : To avoid weird breakages used `./etc/autogen.py -n "security group rule"` to focus on a single namespace.
